### PR TITLE
Add CI caching for aqua and pre-commit dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/share/aquaproj-aqua
-          key: ${{ runner.os }}-aqua-${{ hashFiles('**/aqua.yaml', '**/aqua-checksums.json', '**/aqua/*.yaml') }}
+          key: ${{ runner.os }}-aqua-${{ hashFiles('aqua.yaml') }}
           restore-keys: |
             ${{ runner.os }}-aqua-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,7 @@ jobs:
       - name: Cache aqua packages
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.local/share/aquaproj-aqua
-            ~/aquaproj-aqua
+          path: ~/.local/share/aquaproj-aqua
           key: ${{ runner.os }}-aqua-${{ hashFiles('**/aqua.yaml', '**/aqua-checksums.json', '**/aqua/*.yaml') }}
           restore-keys: |
             ${{ runner.os }}-aqua-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,24 @@ jobs:
         with:
           aqua_version: v2.43.2
 
+      - name: Cache aqua packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/aquaproj-aqua
+            ~/aquaproj-aqua
+          key: ${{ runner.os }}-aqua-${{ hashFiles('**/aqua.yaml', '**/aqua-checksums.json', '**/aqua/*.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-aqua-
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+
       - name: Run pre-commit hooks
         id: pre-commit
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: aquaproj/aqua-installer@v3.1.2
-        with:
-          aqua_version: v2.43.2
-
       - name: Cache aqua packages
         uses: actions/cache@v4
         with:
@@ -29,6 +25,10 @@ jobs:
           key: ${{ runner.os }}-aqua-${{ hashFiles('aqua.yaml') }}
           restore-keys: |
             ${{ runner.os }}-aqua-
+
+      - uses: aquaproj/aqua-installer@v3.1.2
+        with:
+          aqua_version: v2.43.2
 
       - name: Cache pre-commit
         uses: actions/cache@v4


### PR DESCRIPTION
## Why

The CI workflow currently downloads aqua packages and pre-commit hooks on every run, which takes unnecessary time and bandwidth. Adding caching will improve CI performance and reduce execution time.

## What

- Adds GitHub Actions cache for aqua packages (`~/.local/share/aquaproj-aqua`) before aqua-installer runs
- Adds cache for pre-commit hooks (`~/.cache/pre-commit`)  
- Uses appropriate cache keys based on configuration files to ensure cache invalidation when dependencies change

🤖 Generated with [Claude Code](https://claude.ai/code)