### PR TITLE
bin/vibe: add repository name support via ghq integration

### DIFF
--- a/config/bin/lib/vibe/command_done.bash
+++ b/config/bin/lib/vibe/command_done.bash
@@ -64,9 +64,15 @@ handle_done() {
   # Extract name from branch
   local name="${branch#claude/}"
 
-  # Close the specific window by name (regardless of how we got the name)
-  local window_name="${project_name}-${name}"
-  close_tmux_window "$session_name" "${window_name}"
+  # Check if we got the name from current window (no argument case)
+  if [[ "$from_current_window" == "true" ]]; then
+    # Close current window instead of trying to match by name
+    close_tmux_window "$session_name" ""
+  else
+    # Close window by name
+    local window_name="${project_name}-${name}"
+    close_tmux_window "$session_name" "${window_name}"
+  fi
 
   echo "Done! Branch '${branch}' and worktree '${worktree_dir}' have been removed."
 }


### PR DESCRIPTION
## Why

- Currently vibe commands must be run from within a git repository directory, limiting flexibility
- Users need to cd to specific repository directories before running vibe commands
- This creates unnecessary friction when working with multiple repositories

## What

- vibe commands accept a -R/--repo option to specify repositories by name using ghq integration
- Repository names can be short (e.g., "dotfiles") or full (e.g., "fohte/dotfiles")