### PR TITLE
bin/vibe: fix window name calculation

### DIFF
--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -131,9 +131,22 @@ fi
 verify_git_repo
 
 # Get the main git directory (not worktree)
+# Use git rev-parse --git-common-dir to get the shared git directory
 git_common_dir="$(git rev-parse --git-common-dir)"
+# Convert to absolute path if relative
+if [[ "$git_common_dir" != /* ]]; then
+  git_common_dir="$(cd "$(dirname "$git_common_dir")" && pwd)/$(basename "$git_common_dir")"
+fi
+
+# Extract the main repository path from the git directory
 git_root="$(dirname "${git_common_dir}")"
 project_name="$(basename "${git_root}")"
+
+# Fallback to git rev-parse --show-toplevel if project_name is empty or '.'
+if [[ -z "$project_name" || "$project_name" == "." ]]; then
+  git_toplevel="$(git rev-parse --show-toplevel)"
+  project_name="$(basename "$git_toplevel")"
+fi
 
 SESSION_NAME="vibe"
 


### PR DESCRIPTION
## Why

- The `vibe` command generates malformed tmux window names
  - Shows `.-<name>` instead of the expected `dotfiles-<name>` format
  - Occurs when `git rev-parse --git-common-dir` returns a relative path
  - Causes `dirname`/`basename` operations to fail and resolve to `.`
- This causes `vibe done` to fail finding the correct window and potentially close unintended windows
- Proper window naming is essential for identifying and navigating between different vibe sessions

## What

- Window names will display correctly as `project-<name>` format regardless of git directory path resolution
- The `vibe` command handles both absolute and relative git directory paths
  - Adds proper path resolution for relative paths
  - Includes fallback mechanism using `git rev-parse --show-toplevel`
- `vibe done` will reliably find and close the correct window based on proper naming
- User experience improves with consistently formatted and descriptive tmux window names