### PR TITLE
bin/vibe: add `list` command to display active sessions

### DIFF
--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -40,7 +40,7 @@ handle_list() {
 
   # Collect all data first, then format with column
   local table_data=""
-  table_data="REPOSITORY\tNAME\tBRANCH\tPR\tDIRECTORY\tSESSION"
+  table_data="REPOSITORY\tSTATUS\tNAME\tBRANCH\tDIRECTORY\tSESSION"
 
   # List each vibe session with status
   while IFS= read -r branch; do
@@ -63,18 +63,18 @@ handle_list() {
       tmux_status="YES"
     fi
 
-    # Check PR merge status
-    local pr_status
+    # Check session status (done or in-progress)
+    local session_status_value
     if check_pr_merged "${branch}"; then
-      pr_status="MERGED"
+      session_status_value="done"
     elif is_branch_merged "${branch}"; then
-      pr_status="MERGED"
+      session_status_value="done"
     else
-      pr_status="OPEN"
+      session_status_value="in-progress"
     fi
 
-    # Format directory and session status (plain text for column)
-    local directory_status session_status
+    # Format directory and tmux status (plain text for column)
+    local directory_status tmux_session_status
     if [[ "$worktree_status" == "YES" ]]; then
       directory_status="Active"
     else
@@ -82,13 +82,13 @@ handle_list() {
     fi
 
     if [[ "$tmux_status" == "YES" ]]; then
-      session_status="Running"
+      tmux_session_status="Running"
     else
-      session_status="Stopped"
+      tmux_session_status="Stopped"
     fi
 
     # Add row to table data
-    table_data="$table_data\n$repo_name\t$name\t$branch\t$pr_status\t$directory_status\t$session_status"
+    table_data="$table_data\n$repo_name\t$session_status_value\t$name\t$branch\t$directory_status\t$tmux_session_status"
   done <<< "$branches"
 
   # Output formatted table with colors applied after column alignment
@@ -99,8 +99,8 @@ handle_list() {
     else
       # Data row - apply colors to specific fields
       echo "$line" | sed \
-        -e 's/MERGED/\x1b[32mMERGED\x1b[0m/' \
-        -e 's/OPEN/\x1b[33mOPEN\x1b[0m/' \
+        -e 's/done/\x1b[32mdone\x1b[0m/' \
+        -e 's/in-progress/\x1b[33min-progress\x1b[0m/' \
         -e 's/Active/\x1b[32mActive\x1b[0m/' \
         -e 's/Missing/\x1b[31mMissing\x1b[0m/' \
         -e 's/Running/\x1b[32mRunning\x1b[0m/' \

--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -28,7 +28,7 @@ handle_list() {
     return 0
   fi
 
-  echo "Active vibe sessions:"
+  echo -e "\033[1m━━━ Active vibe sessions ━━━\033[0m"
   echo
 
   # Check if tmux session exists
@@ -79,19 +79,38 @@ handle_list() {
       fi
     fi
 
-    # Check PR merge status
-    local pr_status="OPEN"
+    # Check PR merge status with colors
+    local pr_status pr_color
     if check_pr_merged "${branch}"; then
       pr_status="MERGED"
+      pr_color="\033[32m" # green
     elif is_branch_merged "${branch}"; then
       pr_status="MERGED"
+      pr_color="\033[32m" # green
+    else
+      pr_status="OPEN"
+      pr_color="\033[33m" # yellow
     fi
 
-    echo "  $name"
-    echo "    Branch:    $branch $branch_status"
-    echo "    PR:        $pr_status"
-    echo "    Worktree:  $worktree_status $worktree_dir"
-    echo "    Tmux:      $tmux_status $window_name"
+    # Color status indicators
+    local worktree_color tmux_color
+    if [[ "$worktree_status" == "YES" ]]; then
+      worktree_color="\033[32m" # green
+    else
+      worktree_color="\033[31m" # red
+    fi
+
+    if [[ "$tmux_status" == "YES" ]]; then
+      tmux_color="\033[32m" # green
+    else
+      tmux_color="\033[31m" # red
+    fi
+
+    echo -e "  \033[1;36m$name\033[0m"
+    echo -e "    \033[37mBranch:\033[0m    $branch $branch_status"
+    echo -e "    \033[37mPR:\033[0m        ${pr_color}$pr_status\033[0m"
+    echo -e "    \033[37mWorktree:\033[0m  ${worktree_color}$worktree_status\033[0m $worktree_dir"
+    echo -e "    \033[37mTmux:\033[0m      ${tmux_color}$tmux_status\033[0m $window_name"
     echo
   done <<< "$branches"
 }

--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -69,18 +69,18 @@ handle_list() {
       pr_status="OPEN"
     fi
 
-    # Format directory and session status with icons (plain text for column)
+    # Format directory and session status (plain text for column)
     local directory_status session_status
     if [[ "$worktree_status" == "YES" ]]; then
-      directory_status="✅Active"
+      directory_status="Active"
     else
-      directory_status="❌Missing"
+      directory_status="Missing"
     fi
 
     if [[ "$tmux_status" == "YES" ]]; then
-      session_status="✅Running"
+      session_status="Running"
     else
-      session_status="❌Stopped"
+      session_status="Stopped"
     fi
 
     # Add row to table data
@@ -97,10 +97,10 @@ handle_list() {
       echo "$line" | sed \
         -e 's/MERGED/\x1b[32mMERGED\x1b[0m/' \
         -e 's/OPEN/\x1b[33mOPEN\x1b[0m/' \
-        -e 's/✅Active/\x1b[32m✅Active\x1b[0m/' \
-        -e 's/❌Missing/\x1b[31m❌Missing\x1b[0m/' \
-        -e 's/✅Running/\x1b[32m✅Running\x1b[0m/' \
-        -e 's/❌Stopped/\x1b[31m❌Stopped\x1b[0m/'
+        -e 's/Active/\x1b[32mActive\x1b[0m/' \
+        -e 's/Missing/\x1b[31mMissing\x1b[0m/' \
+        -e 's/Running/\x1b[32mRunning\x1b[0m/' \
+        -e 's/Stopped/\x1b[31mStopped\x1b[0m/'
     fi
   done
 }

--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -34,9 +34,13 @@ handle_list() {
     tmux_available=true
   fi
 
+  # Get repository name from git remote
+  local repo_name
+  repo_name=$(git remote get-url origin 2> /dev/null | sed -E 's|.*/([^/]+/[^/]+)(\.git)?$|\1|' | sed 's/\.git$//')
+
   # Collect all data first, then format with column
   local table_data=""
-  table_data="NAME\tBRANCH\tPR\tDIRECTORY\tSESSION"
+  table_data="REPOSITORY\tNAME\tBRANCH\tPR\tDIRECTORY\tSESSION"
 
   # List each vibe session with status
   while IFS= read -r branch; do
@@ -84,12 +88,12 @@ handle_list() {
     fi
 
     # Add row to table data
-    table_data="$table_data\n$name\t$branch\t$pr_status\t$directory_status\t$session_status"
+    table_data="$table_data\n$repo_name\t$name\t$branch\t$pr_status\t$directory_status\t$session_status"
   done <<< "$branches"
 
   # Output formatted table with colors applied after column alignment
   echo -e "$table_data" | column -t | while IFS= read -r line; do
-    if [[ "$line" == "NAME"* ]]; then
+    if [[ "$line" == "REPOSITORY"* ]]; then
       # Header row - make it bold
       echo -e "\033[1m$line\033[0m"
     else

--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -79,8 +79,17 @@ handle_list() {
       fi
     fi
 
+    # Check PR merge status
+    local pr_status="OPEN"
+    if check_pr_merged "${branch}"; then
+      pr_status="MERGED"
+    elif is_branch_merged "${branch}"; then
+      pr_status="MERGED"
+    fi
+
     echo "  $name"
     echo "    Branch:    $branch $branch_status"
+    echo "    PR:        $pr_status"
     echo "    Worktree:  $worktree_status $worktree_dir"
     echo "    Tmux:      $tmux_status $window_name"
     echo

--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# List command functions for vibe
+
+parse_list_command() {
+  # No arguments expected for list command
+  if [[ "$#" -ne 0 ]]; then
+    error_usage "'list' takes no arguments"
+  fi
+}
+
+handle_list() {
+  local git_root="$1"
+  local project_name="$2"
+  local session_name="$3"
+
+  # Get all vibe branches (claude/*)
+  local branches
+  branches=$(git branch --list 'claude/*' --format='%(refname:short)' 2> /dev/null) || {
+    echo "No active vibe sessions found."
+    return 0
+  }
+
+  # Filter out empty results
+  branches=$(echo "$branches" | grep -v '^$' || true)
+
+  if [[ -z "$branches" ]]; then
+    echo "No active vibe sessions found."
+    return 0
+  fi
+
+  echo "Active vibe sessions:"
+  echo
+
+  # Check if tmux session exists
+  local tmux_available=false
+  if tmux_session_exists "$session_name"; then
+    tmux_available=true
+  fi
+
+  # List each vibe session with status
+  while IFS= read -r branch; do
+    [[ -z "$branch" ]] && continue
+
+    local name="${branch#claude/}"
+    local worktree_dir=".worktrees/${name}"
+    local worktree_path="${git_root}/${worktree_dir}"
+    local window_name="${project_name}-${name}"
+
+    # Check if worktree exists
+    local worktree_status="NO"
+    if [[ -d "$worktree_path" ]]; then
+      worktree_status="YES"
+    fi
+
+    # Check if tmux window exists
+    local tmux_status="NO"
+    if [[ "$tmux_available" == "true" ]] && tmux_window_exists "$session_name" "$window_name"; then
+      tmux_status="YES"
+    fi
+
+    # Get branch status (ahead/behind main)
+    local branch_status=""
+    if git show-ref --verify --quiet "refs/heads/${branch}"; then
+      local ahead_behind
+      if ahead_behind=$(git rev-list --left-right --count origin/master..."${branch}" 2> /dev/null); then
+        local behind ahead
+        behind=$(echo "$ahead_behind" | cut -f1)
+        ahead=$(echo "$ahead_behind" | cut -f2)
+
+        if [[ "$ahead" -gt 0 ]] && [[ "$behind" -gt 0 ]]; then
+          branch_status="(ahead $ahead, behind $behind)"
+        elif [[ "$ahead" -gt 0 ]]; then
+          branch_status="(ahead $ahead)"
+        elif [[ "$behind" -gt 0 ]]; then
+          branch_status="(behind $behind)"
+        else
+          branch_status="(up to date)"
+        fi
+      fi
+    fi
+
+    echo "  $name"
+    echo "    Branch:    $branch $branch_status"
+    echo "    Worktree:  $worktree_status $worktree_dir"
+    echo "    Tmux:      $tmux_status $window_name"
+    echo
+  done <<< "$branches"
+}

--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -40,7 +40,7 @@ handle_list() {
 
   # Collect all data first, then format with column
   local table_data=""
-  table_data="REPOSITORY\tSTATUS\tNAME\tBRANCH\tDIRECTORY\tSESSION"
+  table_data="REPOSITORY\tNAME\tSTATUS\tBRANCH\tDIRECTORY\tSESSION"
 
   # List each vibe session with status
   while IFS= read -r branch; do
@@ -88,7 +88,7 @@ handle_list() {
     fi
 
     # Add row to table data
-    table_data="$table_data\n$repo_name\t$session_status_value\t$name\t$branch\t$directory_status\t$tmux_session_status"
+    table_data="$table_data\n$repo_name\t$name\t$session_status_value\t$branch\t$directory_status\t$tmux_session_status"
   done <<< "$branches"
 
   # Output formatted table with colors applied after column alignment

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -10,6 +10,7 @@
 # Usage:
 #   vibe start <name>
 #   vibe done [<name>] [--force|-f]
+#   vibe list
 #
 set -euo pipefail
 
@@ -46,6 +47,9 @@ Commands:
     If <name> is omitted, uses current window name in vibe session
     Use --force or -f to skip merge check
 
+  list
+    List all active vibe sessions with their status
+
 vibe is a wrapper for Claude Code that:
   - Creates/enters a tmux session 'vibe'
   - Creates a git branch 'claude/<name>' from origin/master
@@ -66,6 +70,8 @@ source "${LIB_DIR}/tmux.bash"
 source "${LIB_DIR}/command_start.bash"
 # shellcheck disable=SC1091
 source "${LIB_DIR}/command_done.bash"
+# shellcheck disable=SC1091
+source "${LIB_DIR}/command_list.bash"
 
 # Debug function
 debug() {
@@ -166,6 +172,10 @@ case "$command" in
     worktree_dir=".worktrees/${name}"
     worktree_path="${git_root}/${worktree_dir}"
     handle_done "${branch}" "${worktree_path}" "${worktree_dir}" "${force}" "${SESSION_NAME}" "${project_name}" "${git_root}" "${from_current_window}"
+    ;;
+  list)
+    parse_list_command "$@"
+    handle_list "${git_root}" "${project_name}" "${SESSION_NAME}"
     ;;
   *)
     error_usage "unknown command '$command'"

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -175,7 +175,7 @@ case "$command" in
     ;;
   list)
     parse_list_command "$@"
-    handle_list "${git_root}" "${project_name}" "${SESSION_NAME}"
+    handle_list
     ;;
   *)
     error_usage "unknown command '$command'"


### PR DESCRIPTION
## Why

- Need visibility into all active vibe sessions across repositories  
- Currently no way to see which sessions are active, their PR status, or resource states
- Manual checking of branches, worktrees, and tmux sessions is inefficient

## What

- **New `vibe list` command** displays all active vibe sessions in a table format
- **Repository identification** shows which repo each session belongs to (`fohte/dotfiles`)
- **Status tracking** for PR state (MERGED/OPEN), worktree availability, and tmux sessions
- **Clean formatting** with automatic column alignment and color-coded status indicators
- **Integration** with existing vibe infrastructure (git, tmux, PR detection)