### PR TITLE
feat(vibe): add Claude Code project directory symlink management

### DIFF
--- a/config/bin/lib/vibe/claude_project.bash
+++ b/config/bin/lib/vibe/claude_project.bash
@@ -17,12 +17,12 @@ setup_claude_project_symlink() {
   local git_root="$2"
 
   # Convert paths to Claude Code's directory naming format
-  # Claude Code uses dashes instead of slashes
+  # Claude Code uses dashes instead of slashes and dots
   local worktree_project_name
-  worktree_project_name=$(echo "$worktree_path" | sed 's|^/|-|' | sed 's|/|-|g')
+  worktree_project_name=$(echo "$worktree_path" | sed 's|^/|-|' | sed 's|/|-|g' | sed 's|\.|-|g')
 
   local root_project_name
-  root_project_name=$(echo "$git_root" | sed 's|^/|-|' | sed 's|/|-|g')
+  root_project_name=$(echo "$git_root" | sed 's|^/|-|' | sed 's|/|-|g' | sed 's|\.|-|g')
 
   local claude_projects_dir="${HOME}/.claude/projects"
   local worktree_project_dir="${claude_projects_dir}/${worktree_project_name}"

--- a/config/bin/lib/vibe/claude_project.bash
+++ b/config/bin/lib/vibe/claude_project.bash
@@ -17,12 +17,13 @@ setup_claude_project_symlink() {
   local git_root="$2"
 
   # Convert paths to Claude Code's directory naming format
-  # Claude Code uses dashes instead of slashes and dots
+  # Claude Code replaces all non-alphanumeric characters with dashes
+  # Using printf to avoid trailing newline that would become a dash
   local worktree_project_name
-  worktree_project_name=$(echo "$worktree_path" | sed 's|^/|-|' | sed 's|/|-|g' | sed 's|\.|-|g')
+  worktree_project_name=$(printf '%s' "$worktree_path" | tr -c 'a-zA-Z0-9' '-')
 
   local root_project_name
-  root_project_name=$(echo "$git_root" | sed 's|^/|-|' | sed 's|/|-|g' | sed 's|\.|-|g')
+  root_project_name=$(printf '%s' "$git_root" | tr -c 'a-zA-Z0-9' '-')
 
   local claude_projects_dir="${HOME}/.claude/projects"
   local worktree_project_dir="${claude_projects_dir}/${worktree_project_name}"

--- a/config/bin/lib/vibe/claude_project.bash
+++ b/config/bin/lib/vibe/claude_project.bash
@@ -57,3 +57,24 @@ setup_claude_project_symlink() {
 
   echo "Linked Claude project: worktree → root repository"
 }
+
+# Remove Claude Code project directory symlink
+remove_claude_project_symlink() {
+  local worktree_path="$1"
+
+  # Convert path to Claude Code's directory naming format
+  local worktree_project_name
+  worktree_project_name=$(printf '%s' "$worktree_path" | tr -c 'a-zA-Z0-9' '-')
+
+  local claude_projects_dir="${HOME}/.claude/projects"
+  local worktree_project_dir="${claude_projects_dir}/${worktree_project_name}"
+
+  # Remove symlink if it exists
+  if [[ -L "${worktree_project_dir}" ]]; then
+    debug "Removing Claude project symlink: ${worktree_project_dir}"
+    rm "${worktree_project_dir}"
+    echo "Removed Claude project symlink"
+  else
+    debug "No symlink found at: ${worktree_project_dir}"
+  fi
+}

--- a/config/bin/lib/vibe/claude_project.bash
+++ b/config/bin/lib/vibe/claude_project.bash
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Claude Code project directory management functions
+
+# Debug function (if not already defined)
+if ! declare -f debug > /dev/null; then
+  debug() {
+    if [[ "${VIBE_DEBUG:-}" == "1" ]]; then
+      echo "DEBUG: $*" >&2
+    fi
+  }
+fi
+
+# Setup Claude Code project directory symlink
+# This ensures all worktrees share the same Claude project directory
+setup_claude_project_symlink() {
+  local worktree_path="$1"
+  local git_root="$2"
+
+  # Convert paths to Claude Code's directory naming format
+  # Claude Code uses dashes instead of slashes
+  local worktree_project_name
+  worktree_project_name=$(echo "$worktree_path" | sed 's|^/|-|' | sed 's|/|-|g')
+
+  local root_project_name
+  root_project_name=$(echo "$git_root" | sed 's|^/|-|' | sed 's|/|-|g')
+
+  local claude_projects_dir="${HOME}/.claude/projects"
+  local worktree_project_dir="${claude_projects_dir}/${worktree_project_name}"
+  local root_project_dir="${claude_projects_dir}/${root_project_name}"
+
+  debug "Claude project directories:"
+  debug "  Worktree: ${worktree_project_dir}"
+  debug "  Root: ${root_project_dir}"
+
+  # If worktree project directory already exists and is not a symlink, skip
+  if [[ -e "${worktree_project_dir}" && ! -L "${worktree_project_dir}" ]]; then
+    debug "Worktree project directory already exists and is not a symlink, skipping"
+    return 0
+  fi
+
+  # Create root project directory if it doesn't exist
+  if [[ ! -d "${root_project_dir}" ]]; then
+    debug "Creating root project directory: ${root_project_dir}"
+    mkdir -p "${root_project_dir}"
+  fi
+
+  # Remove existing symlink if it exists
+  if [[ -L "${worktree_project_dir}" ]]; then
+    debug "Removing existing symlink: ${worktree_project_dir}"
+    rm "${worktree_project_dir}"
+  fi
+
+  # Create symlink from worktree project to root project
+  debug "Creating symlink: ${worktree_project_dir} -> ${root_project_dir}"
+  ln -s "${root_project_dir}" "${worktree_project_dir}"
+
+  echo "Linked Claude project: worktree → root repository"
+}

--- a/config/bin/lib/vibe/command_done.bash
+++ b/config/bin/lib/vibe/command_done.bash
@@ -61,6 +61,9 @@ handle_done() {
   remove_worktree "${worktree_path}" "${worktree_dir}"
   delete_branch "${branch}" "${force}"
 
+  # Remove Claude project directory symlink
+  remove_claude_project_symlink "${worktree_path}"
+
   # Extract name from branch
   local name="${branch#claude/}"
 

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -12,6 +12,7 @@ handle_start() {
   local worktree_dir="$3"
   local session_name="$4"
   local project_name="$5"
+  local git_root="$6"
 
   # Check prerequisites
   check_branch_exists "${branch}" && error_exit "Branch '${branch}' already exists"
@@ -28,5 +29,10 @@ handle_start() {
   # Extract name from branch
   local name="${branch#claude/}"
   local window_name="${project_name}-${name}"
+
+  # Setup Claude project directory symlink before starting Claude Code
+  # This needs git_root from the parent scope
+  setup_claude_project_symlink "${worktree_path}" "${git_root}"
+
   start_claude_in_tmux "$session_name" "$window_name" "${worktree_path}" "$create_new_session"
 }

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -67,6 +67,8 @@ source "${LIB_DIR}/git.bash"
 # shellcheck disable=SC1091
 source "${LIB_DIR}/tmux.bash"
 # shellcheck disable=SC1091
+source "${LIB_DIR}/claude_project.bash"
+# shellcheck disable=SC1091
 source "${LIB_DIR}/command_start.bash"
 # shellcheck disable=SC1091
 source "${LIB_DIR}/command_done.bash"
@@ -163,7 +165,7 @@ case "$command" in
     branch="claude/${name}"
     worktree_dir=".worktrees/${name}"
     worktree_path="${git_root}/${worktree_dir}"
-    handle_start "${branch}" "${worktree_path}" "${worktree_dir}" "${SESSION_NAME}" "${project_name}"
+    handle_start "${branch}" "${worktree_path}" "${worktree_dir}" "${SESSION_NAME}" "${project_name}" "${git_root}"
     ;;
   done)
     parsed_output=$(parse_done_command "$@") || exit 1


### PR DESCRIPTION
## Why

- Claude Code creates separate project directories for each git worktree, causing settings and conversation history to be **scattered** across multiple directories
- This fragmentation makes it difficult to maintain consistent Claude Code configurations and loses context between worktrees

## What

- `vibe start` creates a **symlink** from the worktree's Claude project directory to the main repository's project directory
- `vibe done` **removes** the symlink to prevent dangling references
- All worktrees now **share** the same Claude Code settings and conversation history through symlinks

🤖 Generated with [Claude Code](https://claude.ai/code)