### PR TITLE
feat(vibe): allow global options to be placed anywhere in command line

### DIFF
--- a/config/bin/lib/vibe/claude_project.bash
+++ b/config/bin/lib/vibe/claude_project.bash
@@ -55,7 +55,7 @@ setup_claude_project_symlink() {
   debug "Creating symlink: ${worktree_project_dir} -> ${root_project_dir}"
   ln -s "${root_project_dir}" "${worktree_project_dir}"
 
-  echo "Linked Claude project: worktree → root repository"
+  debug "Linked Claude project: worktree → root repository"
 }
 
 # Remove Claude Code project directory symlink
@@ -73,7 +73,7 @@ remove_claude_project_symlink() {
   if [[ -L "${worktree_project_dir}" ]]; then
     debug "Removing Claude project symlink: ${worktree_project_dir}"
     rm "${worktree_project_dir}"
-    echo "Removed Claude project symlink"
+    debug "Removed Claude project symlink"
   else
     debug "No symlink found at: ${worktree_project_dir}"
   fi

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -130,13 +130,6 @@ while [[ $i -lt ${#all_args[@]} ]]; do
       fi
       ((i++)) || true
       ;;
-    --force | -f)
-      # Command-specific options should be passed to command
-      if [[ -n "$command" ]]; then
-        command_args+=("$arg")
-      fi
-      ((i++)) || true
-      ;;
     *)
       # If we have a command, this is a command argument
       if [[ -n "$command" ]]; then

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -130,6 +130,13 @@ while [[ $i -lt ${#all_args[@]} ]]; do
       fi
       ((i++))
       ;;
+    --force | -f)
+      # Command-specific options should be passed to command
+      if [[ -n "$command" ]]; then
+        command_args+=("$arg")
+      fi
+      ((i++))
+      ;;
     *)
       # If we have a command, this is a command argument
       if [[ -n "$command" ]]; then

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -114,7 +114,7 @@ while [[ $i -lt ${#all_args[@]} ]]; do
       ((i++)) || true # move to next argument
       ;;
     -R | --repo)
-      if [[ $((i + 1)) -lt ${#all_args[@]} ]]; then # check if argument exists
+      if [[ $((i + 1)) -lt ${#all_args[@]} ]]; then # check if repo name is provided after -R
         VIBE_REPO_PATH="${all_args[$((i + 1))]}"
         ((i += 2)) || true # skip both -R and its argument
       else

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -96,34 +96,52 @@ resolve_repo_path() {
   echo "$repo_path"
 }
 
-# Parse global options
+# Parse arguments to extract global options and command
 VIBE_DEBUG=0
 VIBE_REPO_PATH=""
-while [[ "$#" -gt 0 ]]; do
-  case "$1" in
+command=""
+command_args=()
+
+# First pass: collect all arguments
+all_args=("$@")
+i=0
+while [[ $i -lt ${#all_args[@]} ]]; do
+  arg="${all_args[$i]}"
+  case "$arg" in
     --debug)
       VIBE_DEBUG=1
-      shift
+      ((i++))
       ;;
     -R | --repo)
-      [[ "$#" -lt 2 ]] && error_usage "option '$1' requires an argument"
-      VIBE_REPO_PATH="$2"
-      shift 2
+      if [[ $((i + 1)) -lt ${#all_args[@]} ]]; then
+        VIBE_REPO_PATH="${all_args[$((i + 1))]}"
+        ((i += 2))
+      else
+        error_usage "option '$arg' requires an argument"
+      fi
       ;;
-    -*)
-      break
+    start | done | list)
+      # Found command
+      if [[ -z "$command" ]]; then
+        command="$arg"
+      else
+        # This is an argument to the command, not the command itself
+        command_args+=("$arg")
+      fi
+      ((i++))
       ;;
     *)
-      break
+      # If we have a command, this is a command argument
+      if [[ -n "$command" ]]; then
+        command_args+=("$arg")
+      fi
+      ((i++))
       ;;
   esac
 done
 
 # Main script
-[[ "$#" -lt 1 ]] && error_usage "missing command"
-
-command="$1"
-shift
+[[ -z "$command" ]] && error_usage "missing command"
 
 # Main execution
 # Change to specified repo directory if provided
@@ -159,14 +177,14 @@ SESSION_NAME="vibe"
 # Parse command and get name
 case "$command" in
   start)
-    name=$(parse_start_command "$@")
+    name=$(parse_start_command "${command_args[@]}")
     branch="claude/${name}"
     worktree_dir=".worktrees/${name}"
     worktree_path="${git_root}/${worktree_dir}"
     handle_start "${branch}" "${worktree_path}" "${worktree_dir}" "${SESSION_NAME}" "${project_name}"
     ;;
   done)
-    parsed_output=$(parse_done_command "$@") || exit 1
+    parsed_output=$(parse_done_command "${command_args[@]}") || exit 1
     read -r name force from_current_window <<< "$parsed_output"
     branch="claude/${name}"
     worktree_dir=".worktrees/${name}"
@@ -174,7 +192,7 @@ case "$command" in
     handle_done "${branch}" "${worktree_path}" "${worktree_dir}" "${force}" "${SESSION_NAME}" "${project_name}" "${git_root}" "${from_current_window}"
     ;;
   list)
-    parse_list_command "$@"
+    parse_list_command "${command_args[@]}"
     handle_list
     ;;
   *)

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -102,20 +102,24 @@ VIBE_REPO_PATH=""
 command=""
 command_args=()
 
-# First pass: collect all arguments
+# Parse arguments: separate global options from command and its arguments
+# We iterate through all arguments to handle options in any position
 all_args=("$@")
 i=0
+# Note: ((i++)) increments i and returns the OLD value
+# When i=0, ((i++)) returns 0, which causes script to exit with set -e
+# Adding || true prevents exit while still incrementing i
 while [[ $i -lt ${#all_args[@]} ]]; do
   arg="${all_args[$i]}"
   case "$arg" in
     --debug)
       VIBE_DEBUG=1
-      ((i++)) || true
+      ((i++)) || true # Move to next argument
       ;;
     -R | --repo)
       if [[ $((i + 1)) -lt ${#all_args[@]} ]]; then
         VIBE_REPO_PATH="${all_args[$((i + 1))]}"
-        ((i += 2)) || true
+        ((i += 2)) || true # Skip both -R and its argument
       else
         error_usage "option '$arg' requires an argument"
       fi

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -129,14 +129,14 @@ while [[ $i -lt ${#all_args[@]} ]]; do
         # This is an argument to the command, not the command itself
         command_args+=("$arg")
       fi
-      ((i++)) || true
+      ((i++)) || true # move to next argument
       ;;
     *)
       # If we have a command, this is a command argument
       if [[ -n "$command" ]]; then
         command_args+=("$arg")
       fi
-      ((i++)) || true
+      ((i++)) || true # move to next argument
       ;;
   esac
 done

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -106,20 +106,17 @@ command_args=()
 # We iterate through all arguments to handle options in any position
 all_args=("$@")
 i=0
-# Note: ((i++)) increments i and returns the OLD value
-# When i=0, ((i++)) returns 0, which causes script to exit with set -e
-# Adding || true prevents exit while still incrementing i
 while [[ $i -lt ${#all_args[@]} ]]; do
   arg="${all_args[$i]}"
   case "$arg" in
     --debug)
       VIBE_DEBUG=1
-      ((i++)) || true # Move to next argument
+      ((i++)) || true # move to next argument
       ;;
     -R | --repo)
       if [[ $((i + 1)) -lt ${#all_args[@]} ]]; then
         VIBE_REPO_PATH="${all_args[$((i + 1))]}"
-        ((i += 2)) || true # Skip both -R and its argument
+        ((i += 2)) || true # skip both -R and its argument
       else
         error_usage "option '$arg' requires an argument"
       fi

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -114,7 +114,7 @@ while [[ $i -lt ${#all_args[@]} ]]; do
       ((i++)) || true # move to next argument
       ;;
     -R | --repo)
-      if [[ $((i + 1)) -lt ${#all_args[@]} ]]; then
+      if [[ $((i + 1)) -lt ${#all_args[@]} ]]; then # check if argument exists
         VIBE_REPO_PATH="${all_args[$((i + 1))]}"
         ((i += 2)) || true # skip both -R and its argument
       else

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -110,12 +110,12 @@ while [[ $i -lt ${#all_args[@]} ]]; do
   case "$arg" in
     --debug)
       VIBE_DEBUG=1
-      ((i++))
+      ((i++)) || true
       ;;
     -R | --repo)
       if [[ $((i + 1)) -lt ${#all_args[@]} ]]; then
         VIBE_REPO_PATH="${all_args[$((i + 1))]}"
-        ((i += 2))
+        ((i += 2)) || true
       else
         error_usage "option '$arg' requires an argument"
       fi
@@ -128,21 +128,21 @@ while [[ $i -lt ${#all_args[@]} ]]; do
         # This is an argument to the command, not the command itself
         command_args+=("$arg")
       fi
-      ((i++))
+      ((i++)) || true
       ;;
     --force | -f)
       # Command-specific options should be passed to command
       if [[ -n "$command" ]]; then
         command_args+=("$arg")
       fi
-      ((i++))
+      ((i++)) || true
       ;;
     *)
       # If we have a command, this is a command argument
       if [[ -n "$command" ]]; then
         command_args+=("$arg")
       fi
-      ((i++))
+      ((i++)) || true
       ;;
   esac
 done


### PR DESCRIPTION
## Why

- The `vibe` command currently requires global options like `-R` and `--debug` to be placed before the subcommand, which is inflexible and unintuitive
- Users naturally want to add options at the end of commands (e.g., `vibe start foo --debug` instead of `vibe --debug start foo`)

## What

- Global options (`-R`/`--repo` and `--debug`) work anywhere in the command line, making the command more flexible and user-friendly
- The argument parser properly separates global options from command-specific arguments regardless of their position
- Command-specific options remain properly scoped to their respective commands (e.g., `--force` only works with `done`)
- The code includes clear inline comments explaining the parsing logic for better maintainability
- Claude project symlink status messages appear only in debug mode, reducing output noise

🤖 Generated with [Claude Code](https://claude.ai/code)