### PR TITLE
feat(vibe): enhance list command to show all repositories and managed sessions

### DIFF
--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -9,56 +9,92 @@ parse_list_command() {
 }
 
 handle_list() {
-
-  # Get all vibe branches (claude/*)
-  local branches
-  branches=$(git branch --list 'claude/*' --format='%(refname:short)' 2> /dev/null) || {
-    echo "No active vibe sessions found."
-    return 0
-  }
-
-  # Filter out empty results
-  branches=$(echo "$branches" | grep -v '^$' || true)
-
-  if [[ -z "$branches" ]]; then
-    echo "No active vibe sessions found."
-    return 0
-  fi
-
-  # Get repository name from git remote
-  local repo_name
-  repo_name=$(git remote get-url origin 2> /dev/null | sed -E 's|.*/([^/]+/[^/]+)(\.git)?$|\1|' | sed 's/\.git$//')
-
   # Collect all data first, then format with column
   local table_data=""
   table_data="REPOSITORY\tNAME\tSTATUS\tPR_URL"
+  local found_any_sessions=false
 
-  # List each vibe session with status
-  while IFS= read -r branch; do
-    [[ -z "$branch" ]] && continue
+  # Get all repositories using ghq
+  local repos
+  repos=$(ghq list --full-path 2> /dev/null) || {
+    echo "Error: ghq not found or no repositories available."
+    return 1
+  }
 
-    local name="${branch#claude/}"
+  # Check each repository for vibe branches
+  while IFS= read -r repo_path; do
+    [[ -z "$repo_path" ]] && continue
+    [[ ! -d "$repo_path" ]] && continue
 
-    # Check session status (done or in-progress) and get PR URL
-    local session_status_value pr_url
-    pr_url=$(gh pr list --state all --head "${branch}" --json url --jq '.[0].url' 2> /dev/null || echo "")
+    # Change to repository directory
+    local original_dir="$PWD"
+    cd "$repo_path" || continue
 
-    if check_pr_merged "${branch}"; then
-      session_status_value="done"
-    elif is_branch_merged "${branch}"; then
-      session_status_value="done"
-    else
-      session_status_value="in-progress"
+    # Get all vibe branches (claude/*) in this repository
+    local branches
+    branches=$(git branch --list 'claude/*' --format='%(refname:short)' 2> /dev/null)
+
+    # Skip if no vibe branches found
+    if [[ -z "$branches" ]]; then
+      cd "$original_dir" || return 1
+      continue
     fi
 
-    # Show "-" if no PR URL found
-    if [[ -z "$pr_url" ]]; then
-      pr_url="-"
+    # Filter out empty results
+    branches=$(echo "$branches" | grep -v '^$' || true)
+
+    if [[ -z "$branches" ]]; then
+      cd "$original_dir" || return 1
+      continue
     fi
 
-    # Add row to table data
-    table_data="$table_data\n$repo_name\t$name\t$session_status_value\t$pr_url"
-  done <<< "$branches"
+    found_any_sessions=true
+
+    # Get repository name from git remote
+    local repo_name
+    repo_name=$(git remote get-url origin 2> /dev/null | sed -E 's|.*/([^/]+/[^/]+)(\.git)?$|\1|' | sed 's/\.git$//')
+
+    # If no remote, use the directory name as fallback
+    if [[ -z "$repo_name" ]]; then
+      repo_name=$(basename "$repo_path")
+    fi
+
+    # List each vibe session with status
+    while IFS= read -r branch; do
+      [[ -z "$branch" ]] && continue
+
+      local name="${branch#claude/}"
+
+      # Check session status (done or in-progress) and get PR URL
+      local session_status_value pr_url
+      pr_url=$(gh pr list --state all --head "${branch}" --json url --jq '.[0].url' 2> /dev/null || echo "")
+
+      if check_pr_merged "${branch}"; then
+        session_status_value="done"
+      elif is_branch_merged "${branch}"; then
+        session_status_value="done"
+      else
+        session_status_value="in-progress"
+      fi
+
+      # Show "-" if no PR URL found
+      if [[ -z "$pr_url" ]]; then
+        pr_url="-"
+      fi
+
+      # Add row to table data
+      table_data="$table_data\n$repo_name\t$name\t$session_status_value\t$pr_url"
+    done <<< "$branches"
+
+    # Return to original directory
+    cd "$original_dir" || return 1
+  done <<< "$repos"
+
+  # Check if any sessions were found
+  if [[ "$found_any_sessions" == false ]]; then
+    echo "No active vibe sessions found."
+    return 0
+  fi
 
   # Output formatted table with colors applied after column alignment
   echo -e "$table_data" | column -t | while IFS= read -r line; do

--- a/config/bin/lib/vibe/command_list.bash
+++ b/config/bin/lib/vibe/command_list.bash
@@ -65,6 +65,12 @@ handle_list() {
 
       local name="${branch#claude/}"
 
+      # Check if worktree exists (only show managed sessions)
+      local worktree_dir=".worktrees/${name}"
+      if [[ ! -d "$worktree_dir" ]]; then
+        continue
+      fi
+
       # Check session status (done or in-progress) and get PR URL
       local session_status_value pr_url
       pr_url=$(gh pr list --state all --head "${branch}" --json url --jq '.[0].url' 2> /dev/null || echo "")

--- a/config/bin/lib/vibe/git.bash
+++ b/config/bin/lib/vibe/git.bash
@@ -90,3 +90,40 @@ delete_branch() {
     git branch -d "${branch}"
   fi
 }
+
+get_pr_url() {
+  local branch="$1"
+  command -v gh &> /dev/null || {
+    echo "-"
+    return 0
+  }
+
+  local pr_url
+  pr_url=$(gh pr list --state all --head "${branch}" --json url --jq '.[0].url' 2> /dev/null || echo "")
+
+  # Show "-" if no PR URL found
+  if [[ -z "$pr_url" ]]; then
+    pr_url="-"
+  fi
+
+  echo "$pr_url"
+}
+
+get_repo_name_from_remote() {
+  local repo_path="$1"
+  local repo_name
+
+  # Try to get from git remote first
+  repo_name=$(git remote get-url origin 2> /dev/null | sed -E 's|.*/([^/]+/[^/]+)(\.git)?$|\1|' | sed 's/\.git$//')
+
+  # If no remote, use the directory name as fallback
+  if [[ -z "$repo_name" ]]; then
+    repo_name=$(basename "$repo_path")
+  fi
+
+  echo "$repo_name"
+}
+
+list_vibe_branches() {
+  git branch --list 'claude/*' --format='%(refname:short)' 2> /dev/null
+}


### PR DESCRIPTION
## Why

- The current `vibe list` command only shows sessions from the current repository, limiting visibility of other active sessions
- Users need a global view of all their active vibe sessions across different repositories
- Orphaned `claude/*` branches without worktrees create noise in the session listing

## What

- `vibe list` will discover sessions across all repositories using `ghq` instead of being limited to the current repository
- Only vibe-managed sessions (those with associated worktrees) will be displayed to reduce clutter
- Git operations are centralized in `lib/git.bash` for better code organization and reusability
- The command maintains the same output format while providing comprehensive cross-repository visibility