### PR TITLE
fix(eza): downgrade to v0.21.3 and skip v0.21.4 in renovate

### DIFF
--- a/config/aqua/aqua.yaml
+++ b/config/aqua/aqua.yaml
@@ -17,7 +17,7 @@ packages:
   - name: neovim/neovim@v0.11.2
   - name: google/go-jsonnet@v0.20.0
   - name: pkgxdev/pkgx@v2.7.0
-  - name: eza-community/eza@v0.21.4
+  - name: eza-community/eza@v0.21.3
   - name: starship/starship@v1.23.0
   - name: BurntSushi/ripgrep@14.1.1
   - name: jdx/mise@v2025.5.16

--- a/renovate.json5
+++ b/renovate.json5
@@ -31,5 +31,9 @@
       automerge: true,
       matchUpdateTypes: ['patch'],
     },
+    {
+      matchPackageNames: ['eza-community/eza'],
+      enabled: false,
+    },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -31,8 +31,10 @@
       automerge: true,
       matchUpdateTypes: ['patch'],
     },
+    // Skip eza v0.21.4 as it's not available on crates.io yet
     {
       matchPackageNames: ['eza-community/eza'],
+      matchNewValue: ['v0.21.4'],
       enabled: false,
     },
   ],


### PR DESCRIPTION
## Why

- eza v0.21.4 causes installation errors because it's not available on crates.io
- This prevents `aqua install` from working properly

## What

- eza stays at v0.21.3 until the crates.io issue is resolved
- renovate skips v0.21.4 updates to prevent automated PRs for the problematic version

🤖 Generated with [Claude Code](https://claude.ai/code)