### PR TITLE
bin/vibe: resolve pane not found error with dots in repository names

### DIFF
--- a/config/bin/lib/vibe/command_done.bash
+++ b/config/bin/lib/vibe/command_done.bash
@@ -73,7 +73,8 @@ handle_done() {
     close_tmux_window "$session_name" ""
   else
     # Close window by name
-    local window_name="${project_name}-${name}"
+    # Replace dots with underscores in window name to match the naming in start command
+    local window_name="${project_name//./_}-${name}"
     close_tmux_window "$session_name" "${window_name}"
   fi
 

--- a/config/bin/lib/vibe/command_done.bash
+++ b/config/bin/lib/vibe/command_done.bash
@@ -42,9 +42,8 @@ handle_done() {
   local worktree_dir="$3"
   local force="$4"
   local session_name="$5"
-  local project_name="$6"
-  local git_root="$7"
-  local from_current_window="${8:-false}"
+  local git_root="$6"
+  local from_current_window="${7:-false}"
 
   # Verify branch exists
   check_branch_exists "${branch}" || error_exit "Branch '${branch}' does not exist"
@@ -70,12 +69,19 @@ handle_done() {
   # Check if we got the name from current window (no argument case)
   if [[ "$from_current_window" == "true" ]]; then
     # Close current window instead of trying to match by name
-    close_tmux_window "$session_name" ""
+    debug "Closing current tmux window..."
+    close_tmux_window_by_id "$session_name" ""
   else
-    # Close window by name
-    # Replace dots with underscores in window name to match the naming in start command
-    local window_name="${project_name//./_}-${name}"
-    close_tmux_window "$session_name" "${window_name}"
+    # Find window ID by vibe name
+    debug "Looking for window with vibe name: ${name}"
+    local window_id
+    window_id=$(get_window_id_by_vibe_name "$session_name" "$name")
+    if [[ -n "$window_id" ]]; then
+      debug "Found window ID: ${window_id}"
+      close_tmux_window_by_id "$session_name" "$window_id"
+    else
+      debug "No window found for vibe name: ${name}"
+    fi
   fi
 
   echo "Done! Branch '${branch}' and worktree '${worktree_dir}' have been removed."

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -192,8 +192,7 @@ handle_start() {
 
   # Extract name from branch
   local name="${branch#claude/}"
-  # Replace dots with underscores in window name to avoid tmux parsing issues
-  local window_name="${project_name//./_}-${name}"
+  local window_name="${project_name}-${name}"
 
   # Setup Claude project directory symlink before starting Claude Code
   # This needs git_root from the parent scope

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -192,7 +192,8 @@ handle_start() {
 
   # Extract name from branch
   local name="${branch#claude/}"
-  local window_name="${project_name}-${name}"
+  # Replace dots with underscores in window name to avoid tmux parsing issues
+  local window_name="${project_name//./_}-${name}"
 
   # Setup Claude project directory symlink before starting Claude Code
   # This needs git_root from the parent scope

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -199,5 +199,7 @@ handle_start() {
   # This needs git_root from the parent scope
   setup_claude_project_symlink "${worktree_path}" "${git_root}"
 
-  start_claude_in_tmux "$session_name" "$window_name" "${worktree_path}" "$create_new_session" "$initial_prompt"
+  local window_id
+  window_id=$(start_claude_in_tmux "$session_name" "$window_name" "${worktree_path}" "$create_new_session" "$initial_prompt")
+  debug "Created tmux window with ID: ${window_id}"
 }

--- a/config/bin/lib/vibe/tmux.bash
+++ b/config/bin/lib/vibe/tmux.bash
@@ -35,7 +35,7 @@ start_claude_in_tmux() {
 
   tmux send-keys -t "$session:$window" "$claude_command" C-m
 
-  tmux switch-client -t "$session" 2> /dev/null || true
+  tmux switch-client -t "$session:$window" 2> /dev/null || true
 }
 
 close_tmux_window() {

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -199,7 +199,7 @@ case "$command" in
     branch="claude/${name}"
     worktree_dir=".worktrees/${name}"
     worktree_path="${git_root}/${worktree_dir}"
-    handle_done "${branch}" "${worktree_path}" "${worktree_dir}" "${force}" "${SESSION_NAME}" "${project_name}" "${git_root}" "${from_current_window}"
+    handle_done "${branch}" "${worktree_path}" "${worktree_dir}" "${force}" "${SESSION_NAME}" "${git_root}" "${from_current_window}"
     ;;
   list)
     parse_list_command "${command_args[@]}"


### PR DESCRIPTION
## Why

- The `vibe start` command was failing with "can't find pane" errors when used with repositories containing dots in their names (e.g., `fohte.net`)
- This occurred because tmux interprets dots as pane separators in the format `session:window.pane`, causing incorrect parsing when switching to windows

## What

- **vibe** now uses tmux window IDs instead of window names for all window operations
- Window names preserve original repository names with dots intact
- The error is completely resolved for all repository names containing special characters