### PR TITLE
vibe: improve tmux window naming format

### DIFF
--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -192,7 +192,7 @@ handle_start() {
 
   # Extract name from branch
   local name="${branch#claude/}"
-  local window_name="${project_name}-${name}"
+  local window_name="${project_name}/${name}"
 
   # Setup Claude project directory symlink before starting Claude Code
   # This needs git_root from the parent scope

--- a/config/bin/lib/vibe/tmux.bash
+++ b/config/bin/lib/vibe/tmux.bash
@@ -9,7 +9,7 @@ get_window_id_by_vibe_name() {
   # List all windows and find the one matching our vibe name pattern
   while IFS=' ' read -r window_id window_name; do
     # Check if window name ends with the vibe name
-    if [[ "$window_name" =~ -${vibe_name}$ ]]; then
+    if [[ "$window_name" =~ /${vibe_name}$ ]]; then
       echo "$window_id"
       return 0
     fi


### PR DESCRIPTION
## Why

- The current window naming format uses hyphens (`repo-name`) which can be visually ambiguous
- Slash separators (`repo/name`) provide better visual separation and are more intuitive as they resemble file paths

## What

- **vibe** tmux window names will use slash format (e.g., `dotfiles/feature-name` instead of `dotfiles-feature-name`)
- Window lookup logic will correctly match the new slash-separated format