### PR TITLE
bin/vibe: add prompt display when starting Claude sessions

### DIFF
--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -134,10 +134,9 @@ parse_start_command() {
     fi
 
     # Display the initial prompt
-    echo -e "\nPrompt" >&2
-    while IFS= read -r line; do
-      echo -e "│ \033[2m$line\033[0m" >&2
-    done <<< "$message"
+    echo -e "\n─ Prompt ─────────────────────────────────" >&2
+    echo -e "\033[2m$message\033[0m" >&2
+    echo -e "──────────────────────────────────────────" >&2
     echo "" >&2
 
     # Return both name and initial prompt
@@ -171,10 +170,9 @@ parse_start_command() {
     fi
 
     # Display the initial prompt
-    echo -e "\nPrompt" >&2
-    while IFS= read -r line; do
-      echo -e "│ \033[2m$line\033[0m" >&2
-    done <<< "$description"
+    echo -e "\n─ Prompt ─────────────────────────────────" >&2
+    echo -e "\033[2m$description\033[0m" >&2
+    echo -e "──────────────────────────────────────────" >&2
     echo "" >&2
 
     # Return both name and initial prompt

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -133,6 +133,11 @@ parse_start_command() {
       read -r suggested_name
     fi
 
+    # Display the initial prompt
+    echo -e "\n🎯 \033[1mInitial prompt:\033[0m" >&2
+    echo -e "\033[36m$message\033[0m" >&2
+    echo "" >&2
+
     # Return both name and initial prompt
     echo "$suggested_name"
     echo "$message"
@@ -162,6 +167,11 @@ parse_start_command() {
       echo -ne "\033[1mEnter your preferred name:\033[0m " >&2
       read -r suggested_name
     fi
+
+    # Display the initial prompt
+    echo -e "\n🎯 \033[1mInitial prompt:\033[0m" >&2
+    echo -e "\033[36m$description\033[0m" >&2
+    echo "" >&2
 
     # Return both name and initial prompt
     echo "$suggested_name"

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -134,9 +134,9 @@ parse_start_command() {
     fi
 
     # Display the initial prompt
-    echo -e "\n🎯 \033[1mInitial prompt:\033[0m" >&2
-    echo -e "\033[30m$message\033[0m" >&2
-    echo "" >&2
+    echo -e "\nPrompt" >&2
+    echo -e "│ \033[30m$message\033[0m" >&2
+    echo -e "│" >&2
 
     # Return both name and initial prompt
     echo "$suggested_name"
@@ -169,9 +169,9 @@ parse_start_command() {
     fi
 
     # Display the initial prompt
-    echo -e "\n🎯 \033[1mInitial prompt:\033[0m" >&2
-    echo -e "\033[30m$description\033[0m" >&2
-    echo "" >&2
+    echo -e "\nPrompt" >&2
+    echo -e "│ \033[30m$description\033[0m" >&2
+    echo -e "│" >&2
 
     # Return both name and initial prompt
     echo "$suggested_name"

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -136,7 +136,7 @@ parse_start_command() {
     # Display the initial prompt
     echo -e "\nPrompt" >&2
     echo -e "│ \033[30m$message\033[0m" >&2
-    echo -e "│" >&2
+    echo "" >&2
 
     # Return both name and initial prompt
     echo "$suggested_name"
@@ -171,7 +171,7 @@ parse_start_command() {
     # Display the initial prompt
     echo -e "\nPrompt" >&2
     echo -e "│ \033[30m$description\033[0m" >&2
-    echo -e "│" >&2
+    echo "" >&2
 
     # Return both name and initial prompt
     echo "$suggested_name"

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -135,7 +135,7 @@ parse_start_command() {
 
     # Display the initial prompt
     echo -e "\n🎯 \033[1mInitial prompt:\033[0m" >&2
-    echo -e "\033[36m$message\033[0m" >&2
+    echo -e "\033[30m$message\033[0m" >&2
     echo "" >&2
 
     # Return both name and initial prompt
@@ -170,7 +170,7 @@ parse_start_command() {
 
     # Display the initial prompt
     echo -e "\n🎯 \033[1mInitial prompt:\033[0m" >&2
-    echo -e "\033[36m$description\033[0m" >&2
+    echo -e "\033[30m$description\033[0m" >&2
     echo "" >&2
 
     # Return both name and initial prompt

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -135,7 +135,9 @@ parse_start_command() {
 
     # Display the initial prompt
     echo -e "\nPrompt" >&2
-    echo -e "│ \033[30m$message\033[0m" >&2
+    while IFS= read -r line; do
+      echo -e "│ \033[2m$line\033[0m" >&2
+    done <<< "$message"
     echo "" >&2
 
     # Return both name and initial prompt
@@ -170,7 +172,9 @@ parse_start_command() {
 
     # Display the initial prompt
     echo -e "\nPrompt" >&2
-    echo -e "│ \033[30m$description\033[0m" >&2
+    while IFS= read -r line; do
+      echo -e "│ \033[2m$line\033[0m" >&2
+    done <<< "$description"
     echo "" >&2
 
     # Return both name and initial prompt

--- a/config/bin/lib/vibe/tmux.bash
+++ b/config/bin/lib/vibe/tmux.bash
@@ -45,15 +45,19 @@ start_claude_in_tmux() {
     window_id=$(tmux new-window -t "$session" -n "$window" -c "${worktree_path}" -P -F "#{window_id}")
   fi
 
-  # Build the claude command with or without initial prompt
+  # Start Claude without initial prompt
   local claude_command="GH_TOKEN=\"\$(gh auth token)\" claude"
-  if [[ -n "$initial_prompt" ]]; then
-    # Escape quotes in the prompt
-    local escaped_prompt="${initial_prompt//\"/\\\"}"
-    claude_command="$claude_command \"$escaped_prompt\""
-  fi
-
   tmux send-keys -t "$window_id" "$claude_command" C-m
+
+  # Display the prompt if provided
+  if [[ -n "$initial_prompt" ]]; then
+    # Wait a moment for Claude to start
+    sleep 1
+    # Display the prompt to the user
+    tmux send-keys -t "$window_id" "echo '🎯 Initial prompt:'" C-m
+    tmux send-keys -t "$window_id" "echo '${initial_prompt//\'/\'\\\'\'}'" C-m
+    tmux send-keys -t "$window_id" "echo ''" C-m
+  fi
 
   tmux switch-client -t "$window_id" 2> /dev/null || true
 

--- a/config/bin/lib/vibe/tmux.bash
+++ b/config/bin/lib/vibe/tmux.bash
@@ -45,19 +45,15 @@ start_claude_in_tmux() {
     window_id=$(tmux new-window -t "$session" -n "$window" -c "${worktree_path}" -P -F "#{window_id}")
   fi
 
-  # Start Claude without initial prompt
+  # Build the claude command with or without initial prompt
   local claude_command="GH_TOKEN=\"\$(gh auth token)\" claude"
-  tmux send-keys -t "$window_id" "$claude_command" C-m
-
-  # Display the prompt if provided
   if [[ -n "$initial_prompt" ]]; then
-    # Wait a moment for Claude to start
-    sleep 1
-    # Display the prompt to the user
-    tmux send-keys -t "$window_id" "echo '🎯 Initial prompt:'" C-m
-    tmux send-keys -t "$window_id" "echo '${initial_prompt//\'/\'\\\'\'}'" C-m
-    tmux send-keys -t "$window_id" "echo ''" C-m
+    # Escape quotes in the prompt
+    local escaped_prompt="${initial_prompt//\"/\\\"}"
+    claude_command="$claude_command \"$escaped_prompt\""
   fi
+
+  tmux send-keys -t "$window_id" "$claude_command" C-m
 
   tmux switch-client -t "$window_id" 2> /dev/null || true
 


### PR DESCRIPTION
## Why

- When `vibe start` fails for any reason (network issues, git conflicts, etc.), users lose the prompt they carefully crafted
- This made it difficult to retry with the same prompt or troubleshoot issues

## What

- **vibe** now displays the initial prompt in the terminal using horizontal line separators
- Long text can wrap naturally without formatting issues
- Both `-m` message mode and editor mode show the prompt before starting Claude