### PR TITLE
vibe: auto-approve branch names with -m flag

### DIFF
--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -98,10 +98,6 @@ parse_start_command() {
   local message=""
   local name=""
   local initial_prompt=""
-  local auto_approve="${1:-false}"
-
-  # Skip the auto_approve parameter
-  shift
 
   # Parse options
   while [[ "$#" -gt 0 ]]; do
@@ -128,19 +124,7 @@ parse_start_command() {
     local suggested_name
     suggested_name=$(generate_name_from_description "$message")
 
-    echo -e "\nSuggested project name: \033[1m$suggested_name\033[0m" >&2
-
-    if [[ "$auto_approve" == "true" ]]; then
-      echo -e "\033[1mAuto-approving name...\033[0m" >&2
-    else
-      echo -ne "\033[1mUse this name? (Y/n):\033[0m " >&2
-      read -r confirm
-
-      if [[ "$confirm" =~ ^[Nn]$ ]]; then
-        echo -ne "\033[1mEnter your preferred name:\033[0m " >&2
-        read -r suggested_name
-      fi
-    fi
+    echo -e "\nGenerated project name: \033[1m$suggested_name\033[0m" >&2
 
     # Display the initial prompt
     echo -e "\n─ Prompt ─────────────────────────────────" >&2
@@ -169,19 +153,7 @@ parse_start_command() {
     local suggested_name
     suggested_name=$(generate_name_from_description "$description")
 
-    echo -e "\nSuggested project name: \033[1m$suggested_name\033[0m" >&2
-
-    if [[ "$auto_approve" == "true" ]]; then
-      echo -e "\033[1mAuto-approving name...\033[0m" >&2
-    else
-      echo -ne "\033[1mUse this name? (Y/n):\033[0m " >&2
-      read -r confirm
-
-      if [[ "$confirm" =~ ^[Nn]$ ]]; then
-        echo -ne "\033[1mEnter your preferred name:\033[0m " >&2
-        read -r suggested_name
-      fi
-    fi
+    echo -e "\nGenerated project name: \033[1m$suggested_name\033[0m" >&2
 
     # Display the initial prompt
     echo -e "\n─ Prompt ─────────────────────────────────" >&2

--- a/config/bin/lib/vibe/command_start.bash
+++ b/config/bin/lib/vibe/command_start.bash
@@ -98,6 +98,10 @@ parse_start_command() {
   local message=""
   local name=""
   local initial_prompt=""
+  local auto_approve="${1:-false}"
+
+  # Skip the auto_approve parameter
+  shift
 
   # Parse options
   while [[ "$#" -gt 0 ]]; do
@@ -125,12 +129,17 @@ parse_start_command() {
     suggested_name=$(generate_name_from_description "$message")
 
     echo -e "\nSuggested project name: \033[1m$suggested_name\033[0m" >&2
-    echo -ne "\033[1mUse this name? (Y/n):\033[0m " >&2
-    read -r confirm
 
-    if [[ "$confirm" =~ ^[Nn]$ ]]; then
-      echo -ne "\033[1mEnter your preferred name:\033[0m " >&2
-      read -r suggested_name
+    if [[ "$auto_approve" == "true" ]]; then
+      echo -e "\033[1mAuto-approving name...\033[0m" >&2
+    else
+      echo -ne "\033[1mUse this name? (Y/n):\033[0m " >&2
+      read -r confirm
+
+      if [[ "$confirm" =~ ^[Nn]$ ]]; then
+        echo -ne "\033[1mEnter your preferred name:\033[0m " >&2
+        read -r suggested_name
+      fi
     fi
 
     # Display the initial prompt
@@ -161,12 +170,17 @@ parse_start_command() {
     suggested_name=$(generate_name_from_description "$description")
 
     echo -e "\nSuggested project name: \033[1m$suggested_name\033[0m" >&2
-    echo -ne "\033[1mUse this name? (Y/n):\033[0m " >&2
-    read -r confirm
 
-    if [[ "$confirm" =~ ^[Nn]$ ]]; then
-      echo -ne "\033[1mEnter your preferred name:\033[0m " >&2
-      read -r suggested_name
+    if [[ "$auto_approve" == "true" ]]; then
+      echo -e "\033[1mAuto-approving name...\033[0m" >&2
+    else
+      echo -ne "\033[1mUse this name? (Y/n):\033[0m " >&2
+      read -r confirm
+
+      if [[ "$confirm" =~ ^[Nn]$ ]]; then
+        echo -ne "\033[1mEnter your preferred name:\033[0m " >&2
+        read -r suggested_name
+      fi
     fi
 
     # Display the initial prompt

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -185,7 +185,16 @@ SESSION_NAME="vibe"
 # Parse command and get name
 case "$command" in
   start)
-    parsed_output=$(parse_start_command "${command_args[@]}")
+    # Check if -m or --message flag is used for auto-approval
+    auto_approve="false"
+    for arg in "${command_args[@]}"; do
+      if [[ "$arg" == "-m" || "$arg" == "--message" ]]; then
+        auto_approve="true"
+        break
+      fi
+    done
+
+    parsed_output=$(parse_start_command "$auto_approve" "${command_args[@]}")
     name=$(echo "$parsed_output" | head -n1)
     initial_prompt=$(echo "$parsed_output" | tail -n+2)
     branch="claude/${name}"

--- a/config/bin/vibe
+++ b/config/bin/vibe
@@ -185,16 +185,7 @@ SESSION_NAME="vibe"
 # Parse command and get name
 case "$command" in
   start)
-    # Check if -m or --message flag is used for auto-approval
-    auto_approve="false"
-    for arg in "${command_args[@]}"; do
-      if [[ "$arg" == "-m" || "$arg" == "--message" ]]; then
-        auto_approve="true"
-        break
-      fi
-    done
-
-    parsed_output=$(parse_start_command "$auto_approve" "${command_args[@]}")
+    parsed_output=$(parse_start_command "${command_args[@]}")
     name=$(echo "$parsed_output" | head -n1)
     initial_prompt=$(echo "$parsed_output" | tail -n+2)
     branch="claude/${name}"


### PR DESCRIPTION
## Why

- The Y/n confirmation prompt when using `vibe start -m` interrupts the workflow
- Users who use the `-m` flag typically trust the auto-generated branch names

## What

- Branch names are automatically approved when using `vibe start -m`
- The confirmation prompt is removed for a smoother developer experience
- Interactive mode (without `-m`) remains unchanged