### PR TITLE
vibe: use temporary file for initial prompt to avoid long command lines

### DIFF
--- a/config/bin/lib/vibe/tmux.bash
+++ b/config/bin/lib/vibe/tmux.bash
@@ -48,9 +48,11 @@ start_claude_in_tmux() {
   # Build the claude command with or without initial prompt
   local claude_command="GH_TOKEN=\"\$(gh auth token)\" claude"
   if [[ -n "$initial_prompt" ]]; then
-    # Escape quotes in the prompt
-    local escaped_prompt="${initial_prompt//\"/\\\"}"
-    claude_command="$claude_command \"$escaped_prompt\""
+    # Write prompt to temporary file and use command substitution
+    local temp_file
+    temp_file=$(mktemp)
+    echo "$initial_prompt" > "$temp_file"
+    claude_command="$claude_command \"\$(cat $temp_file)\""
   fi
 
   tmux send-keys -t "$window_id" "$claude_command" C-m


### PR DESCRIPTION
## Why

- Long initial prompts passed to `vibe start` create excessively long command lines that are difficult to read and debug
- Complex escaping of quotes and special characters in prompts can cause issues and is error-prone

## What

- Initial prompts are now written to temporary files and read via `$(cat tempfile)` instead of being passed directly as command line arguments
- Command lines remain clean and readable regardless of prompt length
- Eliminates escaping complexity when handling prompts with quotes or special characters