### PR TITLE
vibe: fix 'create window failed: index 7 in use' error

### DIFF
--- a/config/bin/lib/vibe/tmux.bash
+++ b/config/bin/lib/vibe/tmux.bash
@@ -42,7 +42,7 @@ start_claude_in_tmux() {
     window_id=$(tmux new-session -ds "$session" -n "$window" -c "${worktree_path}" -P -F "#{window_id}")
   else
     # Create new window and capture window ID
-    window_id=$(tmux new-window -t "$session" -n "$window" -c "${worktree_path}" -P -F "#{window_id}")
+    window_id=$(tmux new-window -a -t "$session" -n "$window" -c "${worktree_path}" -P -F "#{window_id}")
   fi
 
   # Build the claude command with or without initial prompt


### PR DESCRIPTION
## Why

- `vibe start` command was failing with "create window failed: index 7 in use" error
- This happened when tmux's default window index selection conflicted with existing windows

## What

- Add `-a` flag to `tmux new-window` command to insert new windows after the current position
- This avoids index conflicts by using relative positioning instead of absolute index assignment
- Windows are automatically renumbered as needed, maintaining sequential order

🤖 Generated with [Claude Code](https://claude.ai/code)