### PR TITLE
fix: update branch references from master to main for nvim plugins

### DIFF
--- a/config/nvim/lua/plugins/nvim-cmp.lua
+++ b/config/nvim/lua/plugins/nvim-cmp.lua
@@ -104,10 +104,10 @@ return {
       })
     end,
     dependencies = {
-      { 'hrsh7th/cmp-buffer', commit = 'b74fab3656eea9de20a9b8116afa3cfc4ec09657' }, -- renovate: branch=master
-      { 'hrsh7th/cmp-cmdline', commit = 'd126061b624e0af6c3a556428712dd4d4194ec6d' }, -- renovate: branch=master
-      { 'hrsh7th/cmp-nvim-lsp', commit = 'a8912b88ce488f411177fc8aed358b04dc246d7b' }, -- renovate: branch=master
-      { 'hrsh7th/cmp-path', commit = 'c6635aae33a50d6010bf1aa756ac2398a2d54c32' }, -- renovate: branch=master
+      { 'hrsh7th/cmp-buffer', commit = 'b74fab3656eea9de20a9b8116afa3cfc4ec09657' }, -- renovate: branch=main
+      { 'hrsh7th/cmp-cmdline', commit = 'd126061b624e0af6c3a556428712dd4d4194ec6d' }, -- renovate: branch=main
+      { 'hrsh7th/cmp-nvim-lsp', commit = 'a8912b88ce488f411177fc8aed358b04dc246d7b' }, -- renovate: branch=main
+      { 'hrsh7th/cmp-path', commit = 'c6635aae33a50d6010bf1aa756ac2398a2d54c32' }, -- renovate: branch=main
       {
         'petertriho/cmp-git',
         commit = 'b24309c386c9666c549a1abaedd4956541676d06', -- renovate: branch=main

--- a/config/nvim/lua/plugins/telescope.lua
+++ b/config/nvim/lua/plugins/telescope.lua
@@ -3,7 +3,7 @@ return {
   commit = 'b4da76be54691e854d3e0e02c36b0245f945c2c7', -- renovate: branch=master
   dependencies = {
     { 'nvim-lua/plenary.nvim', commit = '857c5ac632080dba10aae49dba902ce3abf91b35' }, -- renovate: branch=master
-    { 'nvim-telescope/telescope-fzf-native.nvim', commit = '1f08ed60cafc8f6168b72b80be2b2ea149813e55', build = 'make' }, -- renovate: branch=master
+    { 'nvim-telescope/telescope-fzf-native.nvim', commit = '1f08ed60cafc8f6168b72b80be2b2ea149813e55', build = 'make' }, -- renovate: branch=main
   },
   keys = {
     {


### PR DESCRIPTION
## Why

- Renovate was showing warnings about being unable to determine new digests for several nvim-cmp plugins and telescope-fzf-native
- These plugins have switched their default branch from `master` to `main`, but the configuration still referenced `master`

## What

- Updates branch references from `master` to `main` for:
  - `hrsh7th/cmp-buffer`
  - `hrsh7th/cmp-cmdline`
  - `hrsh7th/cmp-nvim-lsp`
  - `hrsh7th/cmp-path`
  - `nvim-telescope/telescope-fzf-native.nvim`
- Renovate will now correctly track updates for these plugins

🤖 Generated with [Claude Code](https://claude.ai/code)