### PR TITLE
renovate: stop pinning Node.js in the validate-renovate workflow

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,5 +24,11 @@
       matchDatasources: ['node-version'],
       rangeStrategy: 'bump',
     },
+    {
+      matchManagers: ['github-actions'],
+      matchDatasources: ['node-version'],
+      matchFileNames: ['.github/workflows/validate-renovate.yml'],
+      rangeStrategy: 'bump',
+    },
   ],
 }


### PR DESCRIPTION
## Purpose

- Stop the recurring PRs that pin Node.js to an exact version in a workflow where the validator is the only consumer
    - [validate-renovate.yml](https://github.com/fohte/dotfiles/blob/a7979dce/.github/workflows/validate-renovate.yml) just runs `renovate-config-validator`, so minor/patch precision adds no value

## Approach

- Add a packageRule scoped to that single workflow to suppress `node-version` pin proposals

<details>
<summary>Design decisions</summary>

#### How to scope the rule

| Decision | Design                                                                          | Pros                                                | Cons                                                          |
| -------- | ------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------- |
| Chosen   | Limit via `matchFileNames` to `validate-renovate.yml` only                      | Leaves room to pin Node intentionally elsewhere     | Needs explicit additions if more workflows opt in later       |
| Rejected | Extend the existing mise rule with `matchManagers: ['mise', 'github-actions']`  | Collapses both cases into a single rule             | Forfeits intentional Node pinning in any future workflow      |

</details>
