### PR TITLE
renovate: stop Node.js pin PRs on validate-renovate.yml

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,7 +26,7 @@
     },
     {
       matchManagers: ['github-actions'],
-      matchDatasources: ['node-version'],
+      matchDepNames: ['node'],
       matchFileNames: ['.github/workflows/validate-renovate.yml'],
       rangeStrategy: 'bump',
     },


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/dotfiles/pull/244
- Renovate keeps opening a `renovate/pin-dependencies` PR that pins Node.js in `.github/workflows/validate-renovate.yml`

## Approach

- Fix the suppression rule's matcher so it actually matches the `actions/setup-node` dep
    - Its datasource is `github-releases`, so the existing `matchDatasources: ['node-version']` never matched
